### PR TITLE
Add provider_peering_id to peering resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,7 +195,9 @@ resource "eventstorecloud_peering" "example" {
 
 As well as the input arguments, the following properties are exposed:
 
-- `id` - (`string`) - the ID of the oeering.
+- `id` - (`string`) - the ID of the peering.
+- `provider_peering_id` - (`string`) - the resource-provider-assigned identifier of the peering. This can be used in other
+  Terraform code to accept the peering link.
 
 ## Resource `eventstorecloud_managed_cluster`
 

--- a/client/peering_get.go
+++ b/client/peering_get.go
@@ -9,17 +9,18 @@ import (
 )
 
 type Peering struct {
-	ProjectID             string   `json:"projectId"`
-	PeeringID             string   `json:"id"`
-	NetworkID             string   `json:"networkId"`
-	Provider              string   `json:"provider"`
-	Name                  string   `json:"description"`
-	PeerAccountIdentifier string   `json:"peerAccountId"`
-	PeerNetworkIdentifier string   `json:"peerNetworkId"`
-	PeerNetworkRegion     string   `json:"peerNetworkRegion"`
-	Routes                []string `json:"routes"`
-	Status                string   `json:"status"`
-	Created               string   `json:"created,omitempty"`
+	ProjectID                 string   `json:"projectId"`
+	PeeringID                 string   `json:"id"`
+	NetworkID                 string   `json:"networkId"`
+	Provider                  string   `json:"provider"`
+	Name                      string   `json:"description"`
+	PeerAccountIdentifier     string   `json:"peerAccountId"`
+	PeerNetworkIdentifier     string   `json:"peerNetworkId"`
+	PeerNetworkRegion         string   `json:"peerNetworkRegion"`
+	ProviderPeeringIdentifier string   `json:"providerPeeringId"`
+	Routes                    []string `json:"routes"`
+	Status                    string   `json:"status"`
+	Created                   string   `json:"created,omitempty"`
 }
 
 type GetPeeringRequest struct {

--- a/client/peering_waiter.go
+++ b/client/peering_waiter.go
@@ -12,7 +12,7 @@ type WaitForPeeringStateRequest struct {
 	State          string
 }
 
-func (c *Client) PeeringWaitForState(ctx context.Context, req *WaitForPeeringStateRequest) error {
+func (c *Client) PeeringWaitForState(ctx context.Context, req *WaitForPeeringStateRequest) (*Peering, error) {
 	getRequest := &GetPeeringRequest{
 		OrganizationID: req.OrganizationID,
 		ProjectID:      req.ProjectID,
@@ -22,7 +22,7 @@ func (c *Client) PeeringWaitForState(ctx context.Context, req *WaitForPeeringSta
 	for {
 		resp, err := c.PeeringGet(ctx, getRequest)
 		if err != nil {
-			return err
+			return nil, err
 		}
 
 		if resp.Peering.Status != req.State {
@@ -30,6 +30,6 @@ func (c *Client) PeeringWaitForState(ctx context.Context, req *WaitForPeeringSta
 			continue
 		}
 
-		return nil
+		return &resp.Peering, nil
 	}
 }


### PR DESCRIPTION
This commit adds a new computed field to the peering resource which exposes the resourse-provider-assigned peering identifier. This allows other Terraform code to query for the peering link and accept it in a reliable fashion.

As part of this, we refactor the waiter pattern in the client to return the resource representation from the response which moves into the target state to avoid an additional network request. This should ultimately be propagated to the network and cluster waiters also.