### PR TITLE
change default token directory, create directory if it does not exist

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -26,7 +26,12 @@ func (config *Config) validate() error {
 
 	if _, err := os.Stat(config.TokenStore); err != nil {
 		if os.IsNotExist(err) {
-			return fmt.Errorf("token Store file %q does not exist", config.TokenStore)
+			err := os.MkdirAll(config.TokenStore, 0700)
+			if err != nil {
+				return fmt.Errorf("cannot create path %q: %w", config.TokenStore, err)
+			}
+
+			return nil
 		}
 
 		return fmt.Errorf("error reading Token Store %q: %w", config.TokenStore, err)

--- a/esc/provider.go
+++ b/esc/provider.go
@@ -11,7 +11,7 @@ import (
 	"github.com/EventStore/terraform-provider-eventstorecloud/client"
 )
 
-var defaultTokenStore = filepath.Join(os.Getenv("HOME"), ".bespin", "tokens")
+var defaultTokenStore = filepath.Join(os.Getenv("HOME"), ".esctf", "tokens")
 
 // Provider returns a terraform.ResourceProvider.
 func Provider() terraform.ResourceProvider {


### PR DESCRIPTION
Resolves an overlooked required path creation, and utilizes a nonconflicting storage path by default.