### PR TITLE
change peering provider_metadata back to a map

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,15 @@
-# 1.5.6 (September 2, 2021)
+# 1.5.7 (September 2, 2021)
 
 Enhancements:
 
 * `resource/eventstorecloud_peering`: `provider_metadata` had been inadvertently changed into a set of maps. It's now back to being a map like before.
+
+# 1.5.6 (August 4, 2021)
+
+Enhancements:
+
+* Allow server version "21.6" for managed clusters
+
 
 # 1.5.5 (Jul 20, 2021)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 1.5.6 (September 2, 2021)
+
+Enhancements:
+
+* `resource/eventstorecloud_peering`: `provider_metadata` had been inadvertently changed into a set of maps. It's now back to being a map like before.
+
 # 1.5.5 (Jul 20, 2021)
 
 Enhancements:

--- a/esc/resource_peering.go
+++ b/esc/resource_peering.go
@@ -78,31 +78,11 @@ func resourcePeering() *schema.Resource {
 
 			"provider_metadata": {
 				Description: "Metadata about the remote end of the peering connection",
-				Type:        schema.TypeSet,
+				Type:        schema.TypeMap,
 				Computed:    true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"aws_peering_link_id": {
-							Description: "AWS Peering link ID for the peering. Empty if the peering Provider is not AWS.",
-							Type:        schema.TypeString,
-							Computed:    true,
-						},
-						"gcp_project_id": {
-							Description: "GCP Project ID for the peering. Empty if the peering Provider is not GCP.",
-							Type:        schema.TypeString,
-							Computed:    true,
-						},
-						"gcp_network_name": {
-							Description: "GCP Network Name for the peering. Empty if the peering Provider is not GCP.",
-							Type:        schema.TypeString,
-							Computed:    true,
-						},
-						"gcp_network_id": {
-							Description: "GCP Network ID in URL format. Can be passed to google_compute_network_peering resources. Empty if the peering Provider is not GCP.",
-							Type:        schema.TypeString,
-							Computed:    true,
-						},
-					},
+				Elem: &schema.Schema{
+					Type:     schema.TypeString,
+					Computed: true,
 				},
 			},
 		},
@@ -146,7 +126,7 @@ func resourcePeeringSetProviderMetadata(d *schema.ResourceData, provider string,
 		diags = append(diags, diag.Errorf("Unknown provider %q from Event Store Cloud API", provider)...)
 	}
 
-	if err := d.Set("provider_metadata", []interface{}{providerPeeringMetadata}); err != nil {
+	if err := d.Set("provider_metadata", providerPeeringMetadata); err != nil {
 		diags = append(diags, diag.FromErr(err)...)
 	}
 	return diags

--- a/esc/resource_peering.go
+++ b/esc/resource_peering.go
@@ -3,8 +3,10 @@ package esc
 import (
 	"context"
 	"fmt"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"path"
+
+	"github.com/hashicorp/go-cty/cty"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
@@ -21,6 +23,7 @@ func resourcePeering() *schema.Resource {
 		UpdateContext: resourcePeeringUpdate,
 		DeleteContext: resourcePeeringDelete,
 
+		SchemaVersion: 1,
 		Schema: map[string]*schema.Schema{
 			"project_id": {
 				Description: "Project ID",
@@ -86,7 +89,39 @@ func resourcePeering() *schema.Resource {
 				},
 			},
 		},
+
+		StateUpgraders: []schema.StateUpgrader{
+			{
+				Version: 0,
+				Type:    cty.Object(map[string]cty.Type{}),
+				Upgrade: upgrade1_5_6,
+			},
+		},
 	}
+}
+
+func upgrade1_5_6(_ context.Context, state map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
+	// In version 1.5.6 we accidentally made the field `provider_metadata` into
+	// a set of maps instead of a map. Changing the type back to a map means
+	// users who have projects using 1.5.6 will get an unresolvable situation
+	// that even updating their code can't fix. So we need to check to see if
+	// this item is a map / list, and if so just change it into it's first
+	// (and only) item.
+
+	if providerMetadata, exists := state["provider_metadata"]; exists {
+		providerMetadataList, ok := providerMetadata.([]interface{})
+		if ok {
+			// Because the field was calculated there is no risk the element count will
+			// ever be != 1. If it somehow is though making it into an empty map
+			// should also be safe.
+			if len(providerMetadataList) == 1 {
+				state["provider_metadata"] = providerMetadataList[0]
+			} else {
+				state["provider_metadata"] = map[string]interface{}{}
+			}
+		}
+	}
+	return state, nil
 }
 
 func resourcePeeringSetProviderMetadata(d *schema.ResourceData, provider string, metadata map[string]string) diag.Diagnostics {

--- a/esc/resource_peering.go
+++ b/esc/resource_peering.go
@@ -101,12 +101,12 @@ func resourcePeering() *schema.Resource {
 }
 
 func upgrade1_5_6(_ context.Context, state map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
-	// In version 1.5.6 we accidentally made the field `provider_metadata` into
-	// a set of maps instead of a map. Changing the type back to a map means
-	// users who have projects using 1.5.6 will get an unresolvable situation
-	// that even updating their code can't fix. So we need to check to see if
-	// this item is a map / list, and if so just change it into it's first
-	// (and only) item.
+	// In version 1.5.5 / 1.5.6 we accidentally made the field
+	// `provider_metadata` into a set of maps instead of a map. Changing the
+	// type back to a map means users who have projects using 1.5.6 will get an
+	// unresolvable situation that even updating their code can't fix. So we
+	// need to check to see if this item is a map / list, and if so just change
+	// it into it's first (and only) item.
 
 	if providerMetadata, exists := state["provider_metadata"]; exists {
 		providerMetadataList, ok := providerMetadata.([]interface{})

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.15
 
 require (
 	github.com/hashicorp/go-cleanhttp v0.5.2
+	github.com/hashicorp/go-cty v1.4.1-0.20200414143053-d3edf31b6320
 	github.com/hashicorp/terraform-plugin-docs v0.4.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.6.1
 	github.com/lestrrat-go/jwx v1.0.2


### PR DESCRIPTION
The `provider_metadata` attribute of the peering resource was
inadvertently changed from a map to "set" of schemas resembling the old
map. This change just sets it back to the old behavior.