### PR TITLE
Add defunct state and provide a reasonable error about it

### DIFF
--- a/client/consts.go
+++ b/client/consts.go
@@ -1,3 +1,4 @@
 package client
 
 const StateDeleted = "deleted"
+const StateDefunct = "defunct"

--- a/esc/resource_peering.go
+++ b/esc/resource_peering.go
@@ -252,6 +252,11 @@ func resourcePeeringRead(ctx context.Context, d *schema.ResourceData, meta inter
 		return diags
 	}
 
+	if resp.Peering.Status == client.StateDefunct {
+		diags = append(diags, diag.FromErr(fmt.Errorf("peering entered defunct state, check peering configuration"))...)
+		return diags
+	}
+
 	if err := d.Set("project_id", resp.Peering.ProjectID); err != nil {
 		diags = append(diags, diag.FromErr(err)...)
 	}

--- a/esc/resource_peering.go
+++ b/esc/resource_peering.go
@@ -253,7 +253,7 @@ func resourcePeeringRead(ctx context.Context, d *schema.ResourceData, meta inter
 	}
 
 	if resp.Peering.Status == client.StateDefunct {
-		diags = append(diags, diag.FromErr(fmt.Errorf("peering entered defunct state, check peering configuration"))...)
+		diags = append(diags, diag.FromErr(fmt.Errorf("peering %s (in project %s) entered defunct state, check peering configuration", peeringId, projectId))...)
 		return diags
 	}
 


### PR DESCRIPTION
If peering is in defunct state, there is no error about it during the plan, but metadata is empty so error is a little bit confusing

```
Error: GCP peering link missing remote peering link project identifier
Error: GCP peering link missing remote peering link network identifier
```

This PR will give more reasonable error to users

```
Error: peering entered defunct state, check peering configuration
```