### PR TITLE
adds ability to updated cluster names

### DIFF
--- a/client/cluster_update.go
+++ b/client/cluster_update.go
@@ -46,3 +46,41 @@ func (c *Client) ManagedClusterExpandDisk(ctx context.Context, req *ExpandManage
 
 	return nil
 }
+
+type ManagedClusterUpdateRequest struct {
+	OrganizationID string
+	ProjectID      string
+	ClusterID 	   string
+	Description    string `json:"description"`
+}
+
+func (c *Client) ManagedClusterUpdate(ctx context.Context, req *ManagedClusterUpdateRequest) diag.Diagnostics {
+	requestBody, err := json.Marshal(req)
+	if err != nil {
+		return diag.Errorf("error marshalling request: %w", err)
+	}
+
+	requestURL := *c.apiURL
+	requestURL.Path = path.Join("mesdb", "v1", "organizations", req.OrganizationID, "projects", req.ProjectID, "clusters", req.ClusterID)
+
+	request, err := http.NewRequestWithContext(ctx, http.MethodPut, requestURL.String(), bytes.NewReader(requestBody))
+	if err != nil {
+		return diag.Errorf("error constructing request: %w", err)
+	}
+	request.Header.Add("Content-Type", "application/json")
+	if err := c.addAuthorizationHeader(request); err != nil {
+		return err
+	}
+
+	resp, err := c.httpClient.Do(request)
+	if err != nil {
+		return diag.Errorf("error sending request: %w", err)
+	}
+	defer closeIgnoreError(resp.Body)
+
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusNoContent {
+		return translateStatusCode(resp.StatusCode, "updating cluster", resp.Body)
+	}
+
+	return nil
+}

--- a/esc/resource_managed_cluster.go
+++ b/esc/resource_managed_cluster.go
@@ -37,7 +37,7 @@ func resourceManagedCluster() *schema.Resource {
 			"name": {
 				Description: "Name of the managed cluster",
 				Required:    true,
-				ForceNew:    true,
+				ForceNew:    false,
 				Type:        schema.TypeString,
 			},
 			"topology": {
@@ -221,6 +221,18 @@ func resourceManagedClusterUpdate(ctx context.Context, d *schema.ResourceData, m
 
 	projectId := d.Get("project_id").(string)
 	clusterId := d.Id()
+
+	if d.HasChange("name") {
+		request := &client.ManagedClusterUpdateRequest{
+			OrganizationID: c.organizationId,
+			ProjectID:      projectId,
+			ClusterID:      clusterId,
+			Description: 	d.Get("name").(string),
+		}
+		if err := c.client.ManagedClusterUpdate(ctx, request); err != nil {
+			return err
+		}
+	}
 
 	if d.HasChange("disk_size") {
 		oldI, newI := d.GetChange("disk_size")


### PR DESCRIPTION
Currently changing the cluster name forces a new resource. This code changes it
so instead it just updates the cluster.
