### PR TITLE
Fix peering update, allow deletes of defunct resources

### DIFF
--- a/esc/resource_peering.go
+++ b/esc/resource_peering.go
@@ -213,7 +213,7 @@ func resourcePeeringCreate(ctx context.Context, d *schema.ResourceData, meta int
 		return err
 	}
 
-	return resourcePeeringRead(ctx, d, meta)
+	return resourcePeeringReadCheckDefunct(ctx, d, meta)
 }
 
 func resourcePeeringUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
@@ -236,6 +236,14 @@ func resourcePeeringUpdate(ctx context.Context, d *schema.ResourceData, meta int
 }
 
 func resourcePeeringRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	return resourcePeeringReadWithCheck(ctx, d, meta, false)
+}
+
+func resourcePeeringReadCheckDefunct(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	return resourcePeeringReadWithCheck(ctx, d, meta, true)
+}
+
+func resourcePeeringReadWithCheck(ctx context.Context, d *schema.ResourceData, meta interface{}, errorOnDefunct bool) diag.Diagnostics {
 	c := meta.(*providerContext)
 
 	var diags diag.Diagnostics
@@ -255,7 +263,7 @@ func resourcePeeringRead(ctx context.Context, d *schema.ResourceData, meta inter
 		return diags
 	}
 
-	if resp.Peering.Status == client.StateDefunct {
+	if errorOnDefunct && resp.Peering.Status == client.StateDefunct {
 		diags = append(diags, diag.FromErr(fmt.Errorf("peering %s (in project %s) entered defunct state, check peering configuration", peeringId, projectId))...)
 		return diags
 	}


### PR DESCRIPTION
There was some logic that would check to see if a peering resource was
in a defunct state, and send an error if it was. This was being called
from creates and updates, but also from the normal read which meant
it was impossible to destroy a peering resources that was already in
a defunct state.

This also fixes a bug in peering updates which prevented it from
exiting.

Fixes issue https://github.com/EventStore/terraform-provider-eventstorecloud/issues/61
Fixes issue https://github.com/EventStore/terraform-provider-eventstorecloud/issues/62