### PR TITLE
Adds support back for server version 20.6

### DIFF
--- a/esc/provider.go
+++ b/esc/provider.go
@@ -123,7 +123,7 @@ var slowResourceTimeout = &schema.ResourceTimeout{
 }
 
 var validProviders = []string{"aws", "gcp", "azure"}
-var validServerVersions = []string{"20.10", "21.6", "21.10"}
+var validServerVersions = []string{"20.6", "20.10", "21.6", "21.10"}
 var validTopologies = []string{"single-node", "three-node-multi-zone"}
 var validInstanceTypes = []string{"F1", "C4", "M8", "M16", "M32", "M64", "M128"}
 var validDiskTypes = []string{"GP2", "GP3", "SSD", "PREMIUM-SSD-LRS"}


### PR DESCRIPTION
The Terraform provider was changed awhile back to not allow 20.6, as
it was out of support. This was a good idea, but introduced a problem
that old terraform files which mention clusters with server version 20.6
now raise validation errors that prevent otherwise innocuous actions
such as running "terraform plan" from working (TBH I don't know if 
anyone has been bit by this).

20.6 no longer works with the cluster create call. I'm going to tweak
the error message shown to let users know 20.6 was supported but 
isn't anymore, which should make the experience somewhat intuitive
if anybody tries to create a cluster with 20.6 using terraform. 
Unfortunately they will only see the error message when running apply.

If anyone knows of a way to make terraform allow 20.6 for all actions 
besides create, let me know.