### PR TITLE
Update GCP example: fix project_id and export/import of routes in peering

### DIFF
--- a/examples/gcp/main.tf
+++ b/examples/gcp/main.tf
@@ -38,7 +38,7 @@ resource "eventstorecloud_peering" "peering" {
   peer_resource_provider = eventstorecloud_network.chicken_window.resource_provider
   peer_network_region    = eventstorecloud_network.chicken_window.region
 
-  peer_account_id = data.google_project.project.name
+  peer_account_id = data.google_project.project.project_id
   peer_network_id = data.google_compute_network.network.name
   routes          = [var.peering_route]
 }
@@ -58,9 +58,11 @@ resource "eventstorecloud_managed_cluster" "wings" {
 }
 
 resource "google_compute_network_peering" "example" {
-  name         = "peering"
-  network      = data.google_compute_network.default.id
-  peer_network = eventstorecloud_peering.peering.provider_metadata.gcp_network_id
+  name                 = "peering"
+  network              = data.google_compute_network.default.id
+  peer_network         = eventstorecloud_peering.peering.provider_metadata.gcp_network_id
+  export_custom_routes = true
+  import_custom_routes = true
 }
 
 output "chicken_window_id" {


### PR DESCRIPTION
Hello everyone !
When using the example to deploy Event Store with GCP we identified 2 minor issues : 

- The example is using `project.name` instead of `project.project_id` for the GCP project. Since our project has a different name than its Id, the peering was unable to complete. See [here for argument reference](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/google_project#argument-reference).

- The Import / export routes for peering is `false` by default (see [here](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_network_peering#argument-reference)) but Event Store Cloud documentation recommends us to activate those options : [image in documentation](https://developers.eventstore.com/assets/gcp-peering-3.d6b7f867.png) and [documentation here](https://developers.eventstore.com/cloud/provision/#network-peering-2). 
![Capture d’écran de 2022-04-20 10-09-02](https://user-images.githubusercontent.com/39085621/164181776-aa03ac01-47c3-4a77-a850-498637e6cba2.png)


So this PR aims to fix those 2 issues in example file. Feel free to reach to me if the PR/Commit need to be update to match the contributing guidelines.

Best regards, 
Marius Ambayrac, 
Team Leader @Gojob