### PR TITLE
adds a way to bypass plugin validation

### DIFF
--- a/esc/provider.go
+++ b/esc/provider.go
@@ -81,6 +81,21 @@ func New(version string) func() *schema.Provider {
 		return p
 	}
 }
+
+// This allows the Terraform validation to be bypassed. This can be useful if
+// your using an older version of the plugin which cannot be upgraded for
+// whatever reason and wish to use a newer allowed paramter value that the
+// EventStore Cloud API supports
+func ValidateWithByPass(f schema.SchemaValidateFunc) schema.SchemaValidateFunc {
+	if v := os.Getenv("ESC_BYPASS_VALIDATION"); v != "" {
+		return func(i interface{}, k string) (warnings []string, errors []error) {
+			return nil, nil
+		}
+	} else {
+		return f
+	}
+}
+
 func configure(version string, p *schema.Provider) func(context.Context, *schema.ResourceData) (interface{}, diag.Diagnostics) {
 	return func(_ context.Context, d *schema.ResourceData) (interface{}, diag.Diagnostics) {
 		config := &client.Config{

--- a/esc/resource_managed_cluster.go
+++ b/esc/resource_managed_cluster.go
@@ -51,14 +51,14 @@ func resourceManagedCluster() *schema.Resource {
 				Required:     true,
 				ForceNew:     true,
 				Type:         schema.TypeString,
-				ValidateFunc: validation.StringInSlice(validTopologies, true),
+				ValidateFunc: ValidateWithByPass(validation.StringInSlice(validTopologies, true)),
 			},
 			"instance_type": {
 				Description:  "Instance type of the managed cluster (find the list of valid values below)",
 				Required:     true,
 				ForceNew:     true,
 				Type:         schema.TypeString,
-				ValidateFunc: validation.StringInSlice(validInstanceTypes, true),
+				ValidateFunc: ValidateWithByPass(validation.StringInSlice(validInstanceTypes, true)),
 				StateFunc: func(val interface{}) string {
 					// Normalize to lower case
 					return strings.ToLower(val.(string))
@@ -68,14 +68,14 @@ func resourceManagedCluster() *schema.Resource {
 				Description:  "Size of the data disks, in gigabytes",
 				Required:     true,
 				Type:         schema.TypeInt,
-				ValidateFunc: validation.IntBetween(8, 4096),
+				ValidateFunc: ValidateWithByPass(validation.IntBetween(8, 4096)),
 			},
 			"disk_type": {
 				Description:  "Storage class of the data disks (find the list of valid values below)",
 				Required:     true,
 				ForceNew:     true,
 				Type:         schema.TypeString,
-				ValidateFunc: validation.StringInSlice(validDiskTypes, true),
+				ValidateFunc: ValidateWithByPass(validation.StringInSlice(validDiskTypes, true)),
 				StateFunc: func(val interface{}) string {
 					// Normalize to lower case
 					return strings.ToLower(val.(string))
@@ -96,7 +96,7 @@ func resourceManagedCluster() *schema.Resource {
 				Required:     true,
 				ForceNew:     true,
 				Type:         schema.TypeString,
-				ValidateFunc: validation.StringInSlice(validServerVersions, true),
+				ValidateFunc: ValidateWithByPass(validation.StringInSlice(validServerVersions, true)),
 				StateFunc: func(val interface{}) string {
 					// Normalize to lower case
 					return strings.ToLower(val.(string))
@@ -108,7 +108,7 @@ func resourceManagedCluster() *schema.Resource {
 				ForceNew:     true,
 				Default:      "off",
 				Type:         schema.TypeString,
-				ValidateFunc: validation.StringInSlice(validProjectionLevels, true),
+				ValidateFunc: ValidateWithByPass(validation.StringInSlice(validProjectionLevels, true)),
 				StateFunc: func(val interface{}) string {
 					// Normalize to lower case
 					return strings.ToLower(val.(string))

--- a/esc/resource_network.go
+++ b/esc/resource_network.go
@@ -36,7 +36,7 @@ func resourceNetwork() *schema.Resource {
 				Required:     true,
 				ForceNew:     true,
 				Type:         schema.TypeString,
-				ValidateFunc: validation.StringInSlice(validProviders, true),
+				ValidateFunc: ValidateWithByPass(validation.StringInSlice(validProviders, true)),
 				StateFunc: func(val interface{}) string {
 					// Normalize to lower case
 					return strings.ToLower(val.(string))


### PR DESCRIPTION
This adds a semi-hidden method of bypassing client-side validation,
which could be useful if a mistake ever slips into the local validation
logic run by Terraform or if new capabilities are added but the
Terraform plugin cannot be updated for some reason.