### PR TITLE
Include DiskType on disk expansion

### DIFF
--- a/client/cluster_update.go
+++ b/client/cluster_update.go
@@ -4,16 +4,19 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"net/http"
 	"path"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 )
 
 type ExpandManagedClusterDiskRequest struct {
 	OrganizationID string
 	ProjectID      string
 	ClusterID      string `json:"clusterId"`
+	DiskIops       int32  `json:"diskIops,omitempty"`
 	DiskSizeGB     int32  `json:"diskSizeGb"`
+	DiskThroughput int32  `json:"diskThroughput,omitempty"`
 	DiskType       string `json:"diskType"`
 }
 

--- a/client/cluster_update.go
+++ b/client/cluster_update.go
@@ -14,6 +14,7 @@ type ExpandManagedClusterDiskRequest struct {
 	ProjectID      string
 	ClusterID      string `json:"clusterId"`
 	DiskSizeGB     int32  `json:"diskSizeGb"`
+	DiskType       string `json:"diskType"`
 }
 
 func (c *Client) ManagedClusterExpandDisk(ctx context.Context, req *ExpandManagedClusterDiskRequest) diag.Diagnostics {
@@ -50,7 +51,7 @@ func (c *Client) ManagedClusterExpandDisk(ctx context.Context, req *ExpandManage
 type ManagedClusterUpdateRequest struct {
 	OrganizationID string
 	ProjectID      string
-	ClusterID 	   string
+	ClusterID      string
 	Description    string `json:"description"`
 }
 

--- a/esc/resource_managed_cluster.go
+++ b/esc/resource_managed_cluster.go
@@ -73,7 +73,7 @@ func resourceManagedCluster() *schema.Resource {
 			"disk_type": {
 				Description:  "Storage class of the data disks (find the list of valid values below)",
 				Required:     true,
-				ForceNew:     true,
+				ForceNew:     false,
 				Type:         schema.TypeString,
 				ValidateFunc: ValidateWithByPass(validation.StringInSlice(validDiskTypes, true)),
 				StateFunc: func(val interface{}) string {

--- a/esc/resource_managed_cluster.go
+++ b/esc/resource_managed_cluster.go
@@ -258,10 +258,10 @@ func resourceManagedClusterUpdate(ctx context.Context, d *schema.ResourceData, m
 		}
 	}
 
-	if d.HasChange("disk_size") {
+	if d.HasChange("disk_size") || d.HasChange("disk_type") || d.HasChange("disk_iops") || d.HasChange("disk_throughput") {
 		oldI, newI := d.GetChange("disk_size")
 		oldSize, newSize := oldI.(int), newI.(int)
-		if newSize <= oldSize {
+		if newSize < oldSize {
 			return diag.FromErr(fmt.Errorf("Disks cannot be made smaller - must be %dGB or larger.", oldSize))
 		}
 
@@ -269,7 +269,9 @@ func resourceManagedClusterUpdate(ctx context.Context, d *schema.ResourceData, m
 			OrganizationID: c.organizationId,
 			ProjectID:      projectId,
 			ClusterID:      clusterId,
+			DiskIops:       int32(d.Get("disk_iops").(int)),
 			DiskSizeGB:     int32(newSize),
+			DiskThroughput: int32(d.Get("disk_throughput").(int)),
 			DiskType:       d.Get("disk_type").(string),
 		}
 		if err := c.client.ManagedClusterExpandDisk(ctx, request); err != nil {

--- a/esc/resource_managed_cluster.go
+++ b/esc/resource_managed_cluster.go
@@ -270,6 +270,7 @@ func resourceManagedClusterUpdate(ctx context.Context, d *schema.ResourceData, m
 			ProjectID:      projectId,
 			ClusterID:      clusterId,
 			DiskSizeGB:     int32(newSize),
+			DiskType:       d.Get("disk_type").(string),
 		}
 		if err := c.client.ManagedClusterExpandDisk(ctx, request); err != nil {
 			return err


### PR DESCRIPTION
When upgrading a disk using this Terraform provider, the `DiskType` is not supplied which results in the following error:
```json
...
    "title": "Unable to expand cluster disk",
    "status": 400,
    "detail": "disk type is unknown",
...
```
This PR adds the `DiskType` to the `ExpandManagedClusterDiskRequest` struct to resolve this issue entirely.

Signed-off-by: Joost Buskermolen <joost@buskervezel.nl>