### PR TITLE
Updates to use go 1.18, fixes some CI tools

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,7 +19,7 @@ jobs:
         name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.16
+          go-version: 1.18
       -
         name: Run checks
         run: make ci

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -17,7 +17,7 @@ jobs:
         name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.16
+          go-version: 1.18
       -
         name: Import GPG key
         id: import_gpg
@@ -28,7 +28,7 @@ jobs:
           passphrase: ${{ secrets.GPG_PASSPHRASE }}
       -
         name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v2.5.0
+        uses: goreleaser/goreleaser-action@v3.0.0
         with:
           version: latest
           args: release --rm-dist

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# 1.5.19 (August 1, 2022)
+
+Changes:
+
+* The provider is now built with Go version 1.18
+* Versions of CI tools needed to release the code have been updated to overcome regressions.
+
 # 1.5.18 (August 1, 2022)
 
 Fixes:


### PR DESCRIPTION
I hit some issues trying to release the last version of this provider. It looks like [updating versions of the tools we use to release this code](https://github.com/goreleaser/goreleaser/issues/3224#issuecomment-1175135264) will fix it, so I'm going to try that.

Go-Release v 3.0.0 [says](https://github.com/goreleaser/goreleaser-action/releases) it defaults to using Go 1.18. Despite the introduction of generics and other features I've not observed major regressions on other projects I've used it on. Of course I also built this locally and ran it against the test suite we use against the Cloud backend and confirmed that everything worked.