### PR TITLE
Add 22.6 to valid server versions

### DIFF
--- a/esc/provider.go
+++ b/esc/provider.go
@@ -154,7 +154,7 @@ var slowResourceTimeout = &schema.ResourceTimeout{
 }
 
 var validProviders = []string{"aws", "gcp", "azure"}
-var validServerVersions = []string{"20.6", "20.10", "21.6", "21.10"}
+var validServerVersions = []string{"20.6", "20.10", "21.6", "21.10", "22.6"}
 var validTopologies = []string{"single-node", "three-node-multi-zone"}
 var validInstanceTypes = []string{"F1", "C4", "M8", "M16", "M32", "M64", "M128"}
 var validDiskTypes = []string{"GP2", "GP3", "SSD", "PREMIUM-SSD-LRS"}


### PR DESCRIPTION
- Added 22.6

Question: Should 20.6 and 21.6 remain in the valid server versions list if these versions are out of support?