### PR TITLE
Peering route prefix length right boundary changed from 27 to 28

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+# 1.5.21 (November 18, 2022)
+
+Changes:
+
+* `resource/eventstorecloud_peering` : `routes` prefix length is now allowed to be up to 28 instead of 27.
+
+# 1.5.20 (September 8, 2022)
+
+Changes:
+
+* `server_version` is now 22.6
+
 # 1.5.19 (August 4, 2022)
 
 Changes:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ Changes:
 
 Changes:
 
-* `server_version` is now 22.6
+* Allow server version "22.6" for managed clusters.
 
 # 1.5.19 (August 4, 2022)
 

--- a/esc/resource_peering.go
+++ b/esc/resource_peering.go
@@ -77,7 +77,7 @@ func resourcePeering() *schema.Resource {
 				Required:    true,
 				Elem: &schema.Schema{
 					Type:         schema.TypeString,
-					ValidateFunc: validation.IsCIDRNetwork(8, 27),
+					ValidateFunc: validation.IsCIDRNetwork(8, 28),
 				},
 				Set: schema.HashString,
 			},


### PR DESCRIPTION
Prefix length is now allowed to be up to 28 instead of 27.