### PR TITLE
feat: service account credentials supported

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 Changes:
 
+-   Added Service Account authentication via the OAuth2 client-credentials grant. Set `client_id` and `client_secret` (or `ESC_CLIENT_ID` / `ESC_CLIENT_SECRET`) to authenticate as a Service Account; this takes priority over the `token` refresh-token flow. Service Account tokens are cached in memory only and are never written to the on-disk token store.
+-   Fixed a response-body leak: `closeIgnoreError` returned a closure that deferred call sites never invoked, so HTTP response bodies were never closed.
 -   **Breaking:** Removed support for AWS `gp2` disk type. The upstream Kurrent Cloud API no longer accepts `gp2`; existing clusters should migrate to `gp3` (which requires `disk_iops` and `disk_throughput`). Terraform configurations using `disk_type = "gp2"` will now fail validation locally.
 
 

--- a/client/access_token.go
+++ b/client/access_token.go
@@ -62,14 +62,80 @@ func (c *Client) TokenRefresh(force bool) error {
 	return err
 }
 
-func closeIgnoreError(closer io.Closer) func() {
-	return func() {
-		_ = closer.Close()
+// closeIgnoreError closes closer, discarding any error. It is meant for
+// direct use in defer statements: `defer closeIgnoreError(resp.Body)`.
+func closeIgnoreError(closer io.Closer) {
+	_ = closer.Close()
+}
+
+// isUsable reports whether the token parses as a JWT and has not expired
+// (with 30s of acceptable skew). The signature is deliberately not verified:
+// the provider is the token bearer, not a resource server, and only reads the
+// payload to decide whether to mint a new token. Service Account tokens are
+// not signed with the embedded key, so signature verification is not possible
+// for them anyway.
+func (a accessToken) isUsable() bool {
+	token, err := jwt.ParseString(string(a))
+	if err != nil {
+		return false
 	}
+
+	return jwt.Validate(token, jwt.WithAcceptableSkew(30*time.Second)) == nil
+}
+
+// serviceAccountToken mints an access token via the OAuth2 client-credentials
+// grant for Service Account (machine-to-machine) authentication against the
+// identity kit token endpoint. Only grant_type/client_id/client_secret are
+// sent (the endpoint rejects audience/scope on this grant) and the returned
+// token has no refresh token. Tokens are cached in memory only — Service
+// Account credentials and tokens are never written to the on-disk token store.
+func (c *Client) serviceAccountToken(force bool) (*tokenData, error) {
+	c.saTokenMu.Lock()
+	defer c.saTokenMu.Unlock()
+
+	if c.saToken != nil && !force && c.saToken.AccessToken.isUsable() {
+		return c.saToken, nil
+	}
+
+	log.Printf("[INFO] authenticating via service account client credentials (client_id=%s)", c.clientID)
+
+	idpKitURL := *c.idpKitURL
+	idpKitURL.Path = "/oauth2/token"
+
+	form := url.Values{}
+	form.Set("grant_type", "client_credentials")
+	form.Set("client_id", c.clientID)
+	form.Set("client_secret", c.clientSecret)
+
+	resp, err := c.httpClient.PostForm(idpKitURL.String(), form)
+	if err != nil {
+		return nil, fmt.Errorf("error requesting service account access token: %w", err)
+	}
+	defer closeIgnoreError(resp.Body)
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("error %d requesting service account access token", resp.StatusCode)
+	}
+
+	decoder := json.NewDecoder(resp.Body)
+	result := tokenData{}
+	if err := decoder.Decode(&result); err != nil {
+		return nil, fmt.Errorf("error parsing IDP response: %w", err)
+	}
+
+	c.saToken = &result
+
+	return &result, nil
 }
 
 func (c *Client) accessToken(force bool) (*tokenData, error) {
 	log.Println("[INFO] In the accessToken")
+
+	// Service Account client-credentials takes priority over the refresh
+	// token flow, mirroring the esc CLI.
+	if c.clientSecret != "" {
+		return c.serviceAccountToken(force)
+	}
 
 	if c.tokenStore.exists(c.audience) && !force {
 		tokenData, err := c.tokenStore.get(c.audience)
@@ -82,7 +148,7 @@ func (c *Client) accessToken(force bool) (*tokenData, error) {
 		}
 	}
 
-	log.Println("[INFO] In the IDP")
+	log.Println("[INFO] authenticating via refresh token")
 
 	// Do the refresh
 	idpURL := *c.idpURL

--- a/client/access_token.go
+++ b/client/access_token.go
@@ -10,6 +10,7 @@ import (
 	"log"
 	"net/http"
 	"net/url"
+	"path"
 	"time"
 
 	"github.com/lestrrat-go/jwx/jwa"
@@ -99,8 +100,10 @@ func (c *Client) serviceAccountToken(force bool) (*tokenData, error) {
 
 	log.Printf("[INFO] authenticating via service account client credentials (client_id=%s)", c.clientID)
 
+	// Append to the configured path rather than overwriting it, so a base URL
+	// carrying a path prefix (e.g. behind a reverse proxy) is preserved.
 	idpKitURL := *c.idpKitURL
-	idpKitURL.Path = "/oauth2/token"
+	idpKitURL.Path = path.Join(idpKitURL.Path, "oauth2/token")
 
 	form := url.Values{}
 	form.Set("grant_type", "client_credentials")

--- a/client/access_token_test.go
+++ b/client/access_token_test.go
@@ -1,13 +1,19 @@
 package client
 
 import (
+	"crypto/rand"
+	"crypto/rsa"
 	"encoding/base64"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"path/filepath"
 	"testing"
 	"time"
+
+	"github.com/lestrrat-go/jwx/jwa"
+	"github.com/lestrrat-go/jwx/jwt"
 )
 
 // fakeJWT builds an unsigned JWT with the given expiry. The signature part is
@@ -172,6 +178,64 @@ func TestServiceAccountTokenRefetchesWhenExpired(t *testing.T) {
 
 	if hits != 2 {
 		t.Errorf("token endpoint hit %d times, want 2 (expired token must not be reused)", hits)
+	}
+}
+
+// unwritableStorePath returns a token-store path that os.MkdirAll cannot
+// create, because a regular file sits where a parent directory would need to
+// be (mkdir under a file yields ENOTDIR).
+func unwritableStorePath(t *testing.T) string {
+	t.Helper()
+
+	blocker := filepath.Join(t.TempDir(), "blocker")
+	if err := os.WriteFile(blocker, []byte("x"), 0o600); err != nil {
+		t.Fatalf("creating blocker file: %v", err)
+	}
+
+	return filepath.Join(blocker, "tokens")
+}
+
+// TestNewServiceAccountSkipsTokenStore proves SA mode is memory-only: New
+// succeeds even when the token store cannot be created, and no directory is
+// written. An empty token store path is also accepted.
+func TestNewServiceAccountSkipsTokenStore(t *testing.T) {
+	storePath := unwritableStorePath(t)
+
+	c, err := New(&Config{
+		URL:          "https://api.example.test",
+		ClientID:     "sa-client-id",
+		ClientSecret: "sa-client-secret",
+		TokenStore:   storePath,
+	})
+	if err != nil {
+		t.Fatalf("New rejected SA config over token store access: %v", err)
+	}
+	if _, statErr := os.Stat(storePath); statErr == nil {
+		t.Error("SA mode created the token store on disk; it must be memory-only")
+	}
+
+	// Empty token store must also be accepted in SA mode.
+	if _, err := New(&Config{
+		URL:          "https://api.example.test",
+		ClientID:     "sa-client-id",
+		ClientSecret: "sa-client-secret",
+	}); err != nil {
+		t.Fatalf("New rejected SA config with empty token store: %v", err)
+	}
+
+	_ = c
+}
+
+// TestNewLegacyStillValidatesTokenStore guards the refresh-token path: with no
+// client secret, an uncreatable token store is still a hard error.
+func TestNewLegacyStillValidatesTokenStore(t *testing.T) {
+	_, err := New(&Config{
+		URL:          "https://api.example.test",
+		RefreshToken: "legacy-refresh-token",
+		TokenStore:   unwritableStorePath(t),
+	})
+	if err == nil {
+		t.Fatal("New accepted an uncreatable token store in refresh-token mode, want error")
 	}
 }
 
@@ -472,6 +536,114 @@ func TestAccessTokenLegacyForceSkipsCache(t *testing.T) {
 	}
 	if lastForm["grant_type"] != "refresh_token" {
 		t.Errorf("grant_type = %q, want refresh_token", lastForm["grant_type"])
+	}
+}
+
+// signedJWT mints a JWT signed with a freshly generated RSA key (RS256) and
+// returns both the compact token and the private key used to sign it.
+func signedJWT(t *testing.T, exp time.Time) (string, *rsa.PrivateKey) {
+	t.Helper()
+
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("generating RSA key: %v", err)
+	}
+
+	tok := jwt.New()
+	if err := tok.Set(jwt.ExpirationKey, exp); err != nil {
+		t.Fatalf("setting exp: %v", err)
+	}
+
+	signed, err := jwt.Sign(tok, jwa.RS256, key)
+	if err != nil {
+		t.Fatalf("signing token: %v", err)
+	}
+
+	return string(signed), key
+}
+
+// TestServiceAccountTokenPreservesPathPrefix ensures the client-credentials
+// endpoint is built by appending to the configured identity_kit_url path, not
+// by overwriting it, so a base URL behind a reverse proxy path prefix works.
+func TestServiceAccountTokenPreservesPathPrefix(t *testing.T) {
+	validToken := fakeJWT(t, time.Now().Add(time.Hour))
+
+	var gotPath string
+
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+
+		w.Header().Set("Content-Type", "application/json")
+
+		err := json.NewEncoder(w).Encode(tokenData{
+			AccessToken: accessToken(validToken),
+			ExpiresIn:   86400,
+			TokenType:   "Bearer",
+		})
+		if err != nil {
+			t.Errorf("encoding token response: %v", err)
+		}
+	}))
+	defer backend.Close()
+
+	c, err := New(&Config{
+		URL:            "https://api.example.test",
+		IdentityKitURL: backend.URL + "/auth/kit",
+		ClientID:       "sa-client-id",
+		ClientSecret:   "sa-client-secret",
+		TokenStore:     t.TempDir(),
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	if _, err := c.accessToken(false); err != nil {
+		t.Fatalf("accessToken: %v", err)
+	}
+
+	if gotPath != "/auth/kit/oauth2/token" {
+		t.Errorf("token endpoint path = %q, want /auth/kit/oauth2/token (prefix must be preserved)", gotPath)
+	}
+}
+
+// TestIsUsableIgnoresSignature is the living proof that isUsable performs no
+// signature verification. It signs a token with a real RSA key that the
+// provider has never seen, then asserts:
+//
+//  1. isUsable accepts the token despite the unknown signing key; and
+//  2. a genuine verifier rejects that same key — so the signature is real and
+//     enforceable, and isUsable's acceptance is a deliberate skip, not an
+//     accident of a degenerate signature.
+func TestIsUsableIgnoresSignature(t *testing.T) {
+	signed, signingKey := signedJWT(t, time.Now().Add(time.Hour))
+
+	if !accessToken(signed).isUsable() {
+		t.Fatal("isUsable rejected a non-expired token; it must accept regardless of signer")
+	}
+
+	// A real verifier keyed to a DIFFERENT public key must reject the token,
+	// proving the signature carries meaning that isUsable deliberately skips.
+	otherKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("generating second RSA key: %v", err)
+	}
+	if _, err := jwt.ParseString(signed, jwt.WithVerify(jwa.RS256, &otherKey.PublicKey)); err == nil {
+		t.Fatal("expected signature verification against the wrong key to fail")
+	}
+
+	// Sanity: the same verifier keyed to the correct public key accepts it.
+	if _, err := jwt.ParseString(signed, jwt.WithVerify(jwa.RS256, &signingKey.PublicKey)); err != nil {
+		t.Fatalf("signature verification against the correct key failed: %v", err)
+	}
+}
+
+// TestIsUsableRejectsSignedButExpired confirms isUsable still enforces expiry
+// even for a validly signed token — signature is skipped, claims are not.
+func TestIsUsableRejectsSignedButExpired(t *testing.T) {
+	signed, _ := signedJWT(t, time.Now().Add(-time.Hour))
+
+	if accessToken(signed).isUsable() {
+		t.Fatal("isUsable accepted an expired token")
 	}
 }
 

--- a/client/access_token_test.go
+++ b/client/access_token_test.go
@@ -1,0 +1,496 @@
+package client
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+	"time"
+)
+
+// fakeJWT builds an unsigned JWT with the given expiry. The signature part is
+// filler: token validation in this package deliberately skips signature
+// verification.
+func fakeJWT(t *testing.T, exp time.Time) string {
+	t.Helper()
+
+	header := base64.RawURLEncoding.EncodeToString([]byte(`{"alg":"RS256","typ":"JWT"}`))
+
+	payloadJSON, err := json.Marshal(map[string]int64{
+		"exp": exp.Unix(),
+		"iat": exp.Add(-time.Hour).Unix(),
+	})
+	if err != nil {
+		t.Fatalf("marshalling payload: %v", err)
+	}
+
+	payload := base64.RawURLEncoding.EncodeToString(payloadJSON)
+	signature := base64.RawURLEncoding.EncodeToString([]byte("unsigned"))
+
+	return header + "." + payload + "." + signature
+}
+
+func TestServiceAccountTokenUsesClientCredentialsGrant(t *testing.T) {
+	validToken := fakeJWT(t, time.Now().Add(time.Hour))
+
+	hits := 0
+	lastForm := map[string]string{}
+
+	idpKit := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/oauth2/token" {
+			t.Errorf("unexpected token endpoint path %q, want /oauth2/token", r.URL.Path)
+			http.NotFound(w, r)
+
+			return
+		}
+
+		if err := r.ParseForm(); err != nil {
+			t.Errorf("parsing form: %v", err)
+		}
+
+		hits++
+
+		for key := range r.PostForm {
+			lastForm[key] = r.PostForm.Get(key)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+
+		err := json.NewEncoder(w).Encode(tokenData{
+			AccessToken: accessToken(validToken),
+			ExpiresIn:   86400,
+			TokenType:   "Bearer",
+		})
+		if err != nil {
+			t.Errorf("encoding token response: %v", err)
+		}
+	}))
+	defer idpKit.Close()
+
+	tokenStore := t.TempDir()
+
+	c, err := New(&Config{
+		URL:            "https://api.example.test",
+		IdentityKitURL: idpKit.URL,
+		ClientID:       "sa-client-id",
+		ClientSecret:   "sa-client-secret",
+		TokenStore:     tokenStore,
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	token, err := c.accessToken(false)
+	if err != nil {
+		t.Fatalf("accessToken: %v", err)
+	}
+
+	if string(token.AccessToken) != validToken {
+		t.Errorf("unexpected access token %q", token.AccessToken)
+	}
+
+	want := map[string]string{
+		"grant_type":    "client_credentials",
+		"client_id":     "sa-client-id",
+		"client_secret": "sa-client-secret",
+	}
+	if len(lastForm) != len(want) {
+		t.Errorf("unexpected form fields %v, want exactly %v", lastForm, want)
+	}
+	for key, value := range want {
+		if lastForm[key] != value {
+			t.Errorf("form field %q = %q, want %q", key, lastForm[key], value)
+		}
+	}
+
+	// Second call must be served from the in-memory cache.
+	if _, err := c.accessToken(false); err != nil {
+		t.Fatalf("accessToken (cached): %v", err)
+	}
+	if hits != 1 {
+		t.Errorf("token endpoint hit %d times, want 1 (cached)", hits)
+	}
+
+	// Force must bypass the cache.
+	if err := c.TokenRefresh(true); err != nil {
+		t.Fatalf("TokenRefresh(force): %v", err)
+	}
+	if hits != 2 {
+		t.Errorf("token endpoint hit %d times, want 2 (forced)", hits)
+	}
+
+	// Service Account tokens must never be written to the on-disk store.
+	entries, err := os.ReadDir(tokenStore)
+	if err != nil {
+		t.Fatalf("reading token store dir: %v", err)
+	}
+	if len(entries) != 0 {
+		t.Errorf("token store contains %d entries, want 0 (SA tokens are memory-only)", len(entries))
+	}
+}
+
+func TestServiceAccountTokenRefetchesWhenExpired(t *testing.T) {
+	expiredToken := fakeJWT(t, time.Now().Add(-time.Hour))
+
+	hits := 0
+
+	idpKit := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		hits++
+
+		w.Header().Set("Content-Type", "application/json")
+
+		err := json.NewEncoder(w).Encode(tokenData{
+			AccessToken: accessToken(expiredToken),
+			ExpiresIn:   0,
+			TokenType:   "Bearer",
+		})
+		if err != nil {
+			t.Errorf("encoding token response: %v", err)
+		}
+	}))
+	defer idpKit.Close()
+
+	c, err := New(&Config{
+		URL:            "https://api.example.test",
+		IdentityKitURL: idpKit.URL,
+		ClientID:       "sa-client-id",
+		ClientSecret:   "sa-client-secret",
+		TokenStore:     t.TempDir(),
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	if _, err := c.accessToken(false); err != nil {
+		t.Fatalf("accessToken: %v", err)
+	}
+	if _, err := c.accessToken(false); err != nil {
+		t.Fatalf("accessToken (expired cache): %v", err)
+	}
+
+	if hits != 2 {
+		t.Errorf("token endpoint hit %d times, want 2 (expired token must not be reused)", hits)
+	}
+}
+
+func TestNewRequiresClientIDWithClientSecret(t *testing.T) {
+	_, err := New(&Config{
+		URL:          "https://api.example.test",
+		ClientSecret: "sa-client-secret",
+		TokenStore:   t.TempDir(),
+	})
+	if err == nil {
+		t.Fatal("New accepted client_secret without client_id, want error")
+	}
+}
+
+func TestAccessTokenPrefersServiceAccountOverRefreshToken(t *testing.T) {
+	validToken := fakeJWT(t, time.Now().Add(time.Hour))
+
+	idpKit := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+
+		err := json.NewEncoder(w).Encode(tokenData{
+			AccessToken: accessToken(validToken),
+			ExpiresIn:   86400,
+			TokenType:   "Bearer",
+		})
+		if err != nil {
+			t.Errorf("encoding token response: %v", err)
+		}
+	}))
+	defer idpKit.Close()
+
+	idp := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		t.Error("identity provider must not be called when service account credentials are set")
+		http.Error(w, "unexpected", http.StatusInternalServerError)
+	}))
+	defer idp.Close()
+
+	c, err := New(&Config{
+		URL:                 "https://api.example.test",
+		IdentityProviderURL: idp.URL,
+		IdentityKitURL:      idpKit.URL,
+		ClientID:            "sa-client-id",
+		ClientSecret:        "sa-client-secret",
+		RefreshToken:        "some-refresh-token",
+		TokenStore:          t.TempDir(),
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	if _, err := c.accessToken(false); err != nil {
+		t.Fatalf("accessToken: %v", err)
+	}
+}
+
+func TestAccessTokenLegacyRefreshFlowWithoutClientSecret(t *testing.T) {
+	validToken := fakeJWT(t, time.Now().Add(time.Hour))
+
+	lastForm := map[string]string{}
+
+	idp := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/oauth/token" {
+			t.Errorf("unexpected token endpoint path %q, want /oauth/token", r.URL.Path)
+			http.NotFound(w, r)
+
+			return
+		}
+
+		if err := r.ParseForm(); err != nil {
+			t.Errorf("parsing form: %v", err)
+		}
+
+		for key := range r.PostForm {
+			lastForm[key] = r.PostForm.Get(key)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+
+		err := json.NewEncoder(w).Encode(tokenData{
+			AccessToken: accessToken(validToken),
+			ExpiresIn:   86400,
+			TokenType:   "Bearer",
+		})
+		if err != nil {
+			t.Errorf("encoding token response: %v", err)
+		}
+	}))
+	defer idp.Close()
+
+	c, err := New(&Config{
+		URL:                 "https://api.example.test",
+		IdentityProviderURL: idp.URL,
+		ClientID:            "legacy-client-id",
+		RefreshToken:        "legacy-refresh-token",
+		TokenStore:          t.TempDir(),
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	if _, err := c.accessToken(false); err != nil {
+		t.Fatalf("accessToken: %v", err)
+	}
+
+	if lastForm["grant_type"] != "refresh_token" {
+		t.Errorf("grant_type = %q, want refresh_token", lastForm["grant_type"])
+	}
+	if lastForm["client_id"] != "legacy-client-id" {
+		t.Errorf("client_id = %q, want legacy-client-id", lastForm["client_id"])
+	}
+	if lastForm["refresh_token"] != "legacy-refresh-token" {
+		t.Errorf("refresh_token = %q, want legacy-refresh-token", lastForm["refresh_token"])
+	}
+}
+
+// newLegacyIDP returns an httptest server implementing the legacy
+// /oauth/token refresh endpoint, counting hits and capturing the last form.
+func newLegacyIDP(t *testing.T, token string, hits *int, lastForm map[string]string) *httptest.Server {
+	t.Helper()
+
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/oauth/token" {
+			t.Errorf("unexpected token endpoint path %q, want /oauth/token", r.URL.Path)
+			http.NotFound(w, r)
+
+			return
+		}
+
+		if err := r.ParseForm(); err != nil {
+			t.Errorf("parsing form: %v", err)
+		}
+
+		*hits++
+
+		for key := range r.PostForm {
+			lastForm[key] = r.PostForm.Get(key)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+
+		err := json.NewEncoder(w).Encode(tokenData{
+			AccessToken: accessToken(token),
+			ExpiresIn:   86400,
+			TokenType:   "Bearer",
+		})
+		if err != nil {
+			t.Errorf("encoding token response: %v", err)
+		}
+	}))
+}
+
+func TestNewAllowsClientIDWithoutClientSecret(t *testing.T) {
+	c, err := New(&Config{
+		URL:        "https://api.example.test",
+		ClientID:   "custom-legacy-client-id",
+		TokenStore: t.TempDir(),
+	})
+	if err != nil {
+		t.Fatalf("New rejected client_id without client_secret, breaking legacy configs: %v", err)
+	}
+
+	if c.clientSecret != "" {
+		t.Errorf("clientSecret = %q, want empty", c.clientSecret)
+	}
+}
+
+func TestAccessTokenLegacyDefaultClientID(t *testing.T) {
+	validToken := fakeJWT(t, time.Now().Add(time.Hour))
+
+	hits := 0
+	lastForm := map[string]string{}
+
+	idp := newLegacyIDP(t, validToken, &hits, lastForm)
+	defer idp.Close()
+
+	c, err := New(&Config{
+		URL:                 "https://api.example.test",
+		IdentityProviderURL: idp.URL,
+		RefreshToken:        "legacy-refresh-token",
+		TokenStore:          t.TempDir(),
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	if _, err := c.accessToken(false); err != nil {
+		t.Fatalf("accessToken: %v", err)
+	}
+
+	if lastForm["client_id"] != "OraYp3cFES9O8aWuQtnqi1A7m534iTwt" {
+		t.Errorf("client_id = %q, want default interactive client id", lastForm["client_id"])
+	}
+}
+
+func TestAccessTokenLegacyRefreshWritesTokenStore(t *testing.T) {
+	validToken := fakeJWT(t, time.Now().Add(time.Hour))
+
+	hits := 0
+	lastForm := map[string]string{}
+
+	idp := newLegacyIDP(t, validToken, &hits, lastForm)
+	defer idp.Close()
+
+	tokenStore := t.TempDir()
+
+	c, err := New(&Config{
+		URL:                 "https://api.example.test",
+		IdentityProviderURL: idp.URL,
+		RefreshToken:        "legacy-refresh-token",
+		TokenStore:          tokenStore,
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	if _, err := c.accessToken(false); err != nil {
+		t.Fatalf("accessToken: %v", err)
+	}
+
+	stored, err := c.tokenStore.get(c.audience)
+	if err != nil {
+		t.Fatalf("refreshed token was not written to the token store: %v", err)
+	}
+	if string(stored.AccessToken) != validToken {
+		t.Errorf("stored access token %q, want %q", stored.AccessToken, validToken)
+	}
+}
+
+func TestAccessTokenLegacyInvalidCachedTokenTriggersRefresh(t *testing.T) {
+	validToken := fakeJWT(t, time.Now().Add(time.Hour))
+	expiredToken := fakeJWT(t, time.Now().Add(-time.Hour))
+
+	hits := 0
+	lastForm := map[string]string{}
+
+	idp := newLegacyIDP(t, validToken, &hits, lastForm)
+	defer idp.Close()
+
+	tokenStore := t.TempDir()
+
+	c, err := New(&Config{
+		URL:                 "https://api.example.test",
+		IdentityProviderURL: idp.URL,
+		RefreshToken:        "legacy-refresh-token",
+		TokenStore:          tokenStore,
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	// Pre-place an expired token in the store; it must not be reused.
+	err = c.tokenStore.put(c.audience, tokenData{
+		AccessToken: accessToken(expiredToken),
+		TokenType:   "Bearer",
+	})
+	if err != nil {
+		t.Fatalf("seeding token store: %v", err)
+	}
+
+	token, err := c.accessToken(false)
+	if err != nil {
+		t.Fatalf("accessToken: %v", err)
+	}
+
+	if hits != 1 {
+		t.Errorf("token endpoint hit %d times, want 1 (expired cached token must trigger refresh)", hits)
+	}
+	if string(token.AccessToken) != validToken {
+		t.Errorf("access token %q, want freshly refreshed token", token.AccessToken)
+	}
+}
+
+func TestAccessTokenLegacyForceSkipsCache(t *testing.T) {
+	validToken := fakeJWT(t, time.Now().Add(time.Hour))
+
+	hits := 0
+	lastForm := map[string]string{}
+
+	idp := newLegacyIDP(t, validToken, &hits, lastForm)
+	defer idp.Close()
+
+	c, err := New(&Config{
+		URL:                 "https://api.example.test",
+		IdentityProviderURL: idp.URL,
+		RefreshToken:        "legacy-refresh-token",
+		TokenStore:          t.TempDir(),
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	if err := c.TokenRefresh(true); err != nil {
+		t.Fatalf("TokenRefresh(force): %v", err)
+	}
+
+	if hits != 1 {
+		t.Errorf("token endpoint hit %d times, want 1", hits)
+	}
+	if lastForm["grant_type"] != "refresh_token" {
+		t.Errorf("grant_type = %q, want refresh_token", lastForm["grant_type"])
+	}
+}
+
+func TestAccessTokenIsUsable(t *testing.T) {
+	cases := []struct {
+		name  string
+		token string
+		want  bool
+	}{
+		{name: "valid", token: fakeJWT(t, time.Now().Add(time.Hour)), want: true},
+		{name: "expired", token: fakeJWT(t, time.Now().Add(-time.Hour)), want: false},
+		{name: "garbage", token: "not-a-jwt", want: false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := accessToken(tc.token).isUsable(); got != tc.want {
+				t.Errorf("isUsable() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}

--- a/client/client.go
+++ b/client/client.go
@@ -7,6 +7,7 @@ import (
 	"net/url"
 	"os"
 	"strings"
+	"sync"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 
@@ -16,7 +17,9 @@ import (
 type Config struct {
 	URL                 string
 	IdentityProviderURL string
+	IdentityKitURL      string
 	ClientID            string
+	ClientSecret        string
 	TokenStore          string
 	RefreshToken        string
 }
@@ -47,9 +50,16 @@ type Client struct {
 
 	audience     string
 	idpURL       *url.URL
+	idpKitURL    *url.URL
 	tokenStore   *tokenStore
 	clientID     string
+	clientSecret string
 	refreshToken string
+
+	// saTokenMu guards saToken. Service Account tokens are cached in memory
+	// only and are never written to the on-disk token store.
+	saTokenMu sync.Mutex
+	saToken   *tokenData
 
 	httpClient *http.Client
 }
@@ -57,6 +67,13 @@ type Client struct {
 func New(opts *Config) (*Client, error) {
 	if err := opts.validate(); err != nil {
 		return nil, err
+	}
+
+	// Service Account authentication requires both halves of the credential
+	// pair; a secret without an explicit client id would otherwise silently
+	// fall back to the default interactive client id.
+	if strings.TrimSpace(opts.ClientSecret) != "" && strings.TrimSpace(opts.ClientID) == "" {
+		return nil, errors.New("client_id and client_secret must both be set for service account authentication")
 	}
 
 	tokenStore := &tokenStore{
@@ -77,6 +94,15 @@ func New(opts *Config) (*Client, error) {
 		return nil, fmt.Errorf("invalid identity provider URL: %q, %w", identityProviderURL, err)
 	}
 
+	identityKitURL := opts.IdentityKitURL
+	if strings.TrimSpace(identityKitURL) == "" {
+		identityKitURL = "https://thorough-shelter-35.authkit.app"
+	}
+	parsedIdentityKitURL, err := url.Parse(identityKitURL)
+	if err != nil {
+		return nil, fmt.Errorf("invalid identity kit URL: %q, %w", identityKitURL, err)
+	}
+
 	clientID := opts.ClientID
 	if strings.TrimSpace(clientID) == "" {
 		clientID = "OraYp3cFES9O8aWuQtnqi1A7m534iTwt"
@@ -86,7 +112,9 @@ func New(opts *Config) (*Client, error) {
 		apiURL:       apiURL,
 		audience:     "api.eventstore.cloud",
 		idpURL:       parsedIdentityProviderURL,
+		idpKitURL:    parsedIdentityKitURL,
 		clientID:     clientID,
+		clientSecret: strings.TrimSpace(opts.ClientSecret),
 		tokenStore:   tokenStore,
 		refreshToken: opts.RefreshToken,
 		httpClient:   newHTTPClientWithUserAgent(cleanhttp.DefaultClient()),

--- a/client/client.go
+++ b/client/client.go
@@ -109,7 +109,7 @@ func New(opts *Config) (*Client, error) {
 
 	identityKitURL := opts.IdentityKitURL
 	if strings.TrimSpace(identityKitURL) == "" {
-		identityKitURL = "https://thorough-shelter-35.authkit.app"
+		identityKitURL = "https://auth.kurrent.io"
 	}
 	parsedIdentityKitURL, err := url.Parse(identityKitURL)
 	if err != nil {

--- a/client/client.go
+++ b/client/client.go
@@ -24,9 +24,22 @@ type Config struct {
 	RefreshToken        string
 }
 
+// serviceAccountMode reports whether the config selects Service Account
+// (client-credentials) authentication, i.e. a client secret is present.
+func (config *Config) serviceAccountMode() bool {
+	return strings.TrimSpace(config.ClientSecret) != ""
+}
+
 func (config *Config) validate() error {
 	if strings.TrimSpace(config.URL) == "" {
 		return errors.New("URL is required")
+	}
+
+	// Service Account authentication is memory-only: it never reads or writes
+	// the on-disk token store, so don't require (or create) it. This keeps SA
+	// mode usable in environments with no writable filesystem.
+	if config.serviceAccountMode() {
+		return nil
 	}
 
 	if _, err := os.Stat(config.TokenStore); err != nil {

--- a/docs/index.md
+++ b/docs/index.md
@@ -12,15 +12,21 @@ Use the navigation to the left to read about the available resources.
 
 ## Configuration
 
-The Kurrent Cloud provider must be configured with an access token, however there are several additional options which may be useful.
+The Kurrent Cloud provider supports two authentication methods:
+
+- **Service Account credentials (recommended for automation)** - set `client_id` and `client_secret` to the credentials of a Kurrent Cloud Service Account. The provider then obtains short-lived access tokens via the OAuth2 client-credentials grant, and `token` is not used.
+- **Refresh token** - set `token` to a personal refresh token. This is the legacy method; the token is bound to a user account.
 
 Provider configuration options are:
 
-- `token` - (`ESC_TOKEN` via the environment) - *Required* - a refresh token for Kurrent Cloud. This token can be created and displayed with the esc cli tool [esc cli](https://github.com/EventStore/esc), or via the "request refresh token" button on the [Authentification Tokens page](https://console.eventstore.cloud/authentication-tokens) in the console. The token id displayed in the cloud console is not a valid token.
+- `token` - (`ESC_TOKEN` via the environment) - *Required unless Service Account credentials are set* - a refresh token for Kurrent Cloud. This token can be created and displayed with the esc cli tool [esc cli](https://github.com/EventStore/esc), or via the "request refresh token" button on the [Authentification Tokens page](https://console.eventstore.cloud/authentication-tokens) in the console. The token id displayed in the cloud console is not a valid token.
 - `organization_id` - (`ESC_ORG_ID` via the environment) - *Required* - the identifier of the Kurrent Cloud organization into which to provision resources.
 
+- `client_id` - (`ESC_CLIENT_ID` via the environment) - *Optional* - the Service Account client id. Must be set together with `client_secret`.
+- `client_secret` - (`ESC_CLIENT_SECRET` via the environment) - *Optional* - the Service Account client secret. When both `client_id` and `client_secret` are set, Service Account authentication is used and takes priority over `token`. Service Account tokens are held in memory only and are never written to the token store.
 - `url` - (`ESC_URL` via the environment) - *Optional* - the URL of the Kurrent Cloud API. This defaults to the public cloud instance of Kurrent Cloud, but may be overridden to provision resources in another instance.
-- `token_store` - (`ESC_TOKEN_STORE` via the environment) - *Optional* - the location on the local filesystem of the token cache. This is shared with the Kurrent Cloud CLI.
+- `token_store` - (`ESC_TOKEN_STORE` via the environment) - *Optional* - the location on the local filesystem of the token cache. This is shared with the Kurrent Cloud CLI. Only used with refresh token authentication.
+- `identity_kit_url` - (`ESC_IDENTITY_KIT_URL` via the environment) - *Optional* - the base URL of the token endpoint used for Service Account authentication. You would normally not need to set it.
 
 ## Example Usage
 
@@ -49,6 +55,8 @@ provider "kurrentcloud" {
 ### Optional
 
 - **client_id** (String)
+- **client_secret** (String, Sensitive)
+- **identity_kit_url** (String)
 - **identity_provider_url** (String)
 - **organization_id** (String)
 - **token** (String, Sensitive)

--- a/docs/index.md
+++ b/docs/index.md
@@ -14,12 +14,14 @@ Use the navigation to the left to read about the available resources.
 
 The Kurrent Cloud provider supports two authentication methods:
 
-- **Service Account credentials (recommended for automation)** - set `client_id` and `client_secret` to the credentials of a Kurrent Cloud Service Account. The provider then obtains short-lived access tokens via the OAuth2 client-credentials grant, and `token` is not used.
+- **Service Account credentials (recommended)** - set `client_id` and `client_secret` to the credentials of a Kurrent Cloud Service Account. The provider then obtains short-lived access tokens via the OAuth2 client-credentials grant, and `token` is not used.
 - **Refresh token** - set `token` to a personal refresh token. This is the legacy method; the token is bound to a user account.
+
+~> **Deprecation:** Refresh token authentication is a legacy method and will be **decommissioned soon**. Migrate to Service Account credentials (`client_id` / `client_secret`) as described below. Service Accounts are not bound to a user account, hold no token on disk, and are the supported path going forward.
 
 Provider configuration options are:
 
-- `token` - (`ESC_TOKEN` via the environment) - *Required unless Service Account credentials are set* - a refresh token for Kurrent Cloud. This token can be created and displayed with the esc cli tool [esc cli](https://github.com/EventStore/esc), or via the "request refresh token" button on the [Authentification Tokens page](https://console.eventstore.cloud/authentication-tokens) in the console. The token id displayed in the cloud console is not a valid token.
+- `token` - (`ESC_TOKEN` via the environment) - *Required unless Service Account credentials are set* - **(deprecated, see above)** a refresh token for Kurrent Cloud. This token can be created and displayed with the esc cli tool [esc cli](https://github.com/EventStore/esc), or via the "request refresh token" button on the [Authentification Tokens page](https://console.eventstore.cloud/authentication-tokens) in the console. The token id displayed in the cloud console is not a valid token.
 - `organization_id` - (`ESC_ORG_ID` via the environment) - *Required* - the identifier of the Kurrent Cloud organization into which to provision resources.
 
 - `client_id` - (`ESC_CLIENT_ID` via the environment) - *Optional* - the Service Account client id. Must be set together with `client_secret`.

--- a/esc/provider.go
+++ b/esc/provider.go
@@ -71,6 +71,19 @@ func New(version string) func() *schema.Provider {
 					Required:    true,
 					DefaultFunc: schema.EnvDefaultFunc("ESC_CLIENT_ID", ""),
 				},
+
+				"client_secret": {
+					Type:        schema.TypeString,
+					Optional:    true,
+					DefaultFunc: schema.EnvDefaultFunc("ESC_CLIENT_SECRET", ""),
+					Sensitive:   true,
+				},
+
+				"identity_kit_url": {
+					Type:        schema.TypeString,
+					Optional:    true,
+					DefaultFunc: schema.EnvDefaultFunc("ESC_IDENTITY_KIT_URL", ""),
+				},
 			},
 
 			DataSourcesMap: map[string]*schema.Resource{
@@ -143,7 +156,9 @@ func configure(
 			RefreshToken:        d.Get("token").(string),
 			TokenStore:          d.Get("token_store").(string),
 			IdentityProviderURL: d.Get("identity_provider_url").(string),
+			IdentityKitURL:      d.Get("identity_kit_url").(string),
 			ClientID:            d.Get("client_id").(string),
+			ClientSecret:        d.Get("client_secret").(string),
 		}
 
 		c, err := client.New(config)

--- a/esc/provider_test.go
+++ b/esc/provider_test.go
@@ -1,0 +1,11 @@
+package esc
+
+import (
+	"testing"
+)
+
+func TestProviderInternalValidate(t *testing.T) {
+	if err := New("test")().InternalValidate(); err != nil {
+		t.Fatalf("provider schema failed validation: %v", err)
+	}
+}

--- a/templates/index.md.tmpl
+++ b/templates/index.md.tmpl
@@ -16,15 +16,21 @@ Use the navigation to the left to read about the available resources.
 
 ## Configuration
 
-The Kurrent Cloud provider must be configured with an access token, however there are several additional options which may be useful.
+The Kurrent Cloud provider supports two authentication methods:
+
+- **Service Account credentials (recommended for automation)** - set `client_id` and `client_secret` to the credentials of a Kurrent Cloud Service Account. The provider then obtains short-lived access tokens via the OAuth2 client-credentials grant, and `token` is not used.
+- **Refresh token** - set `token` to a personal refresh token. This is the legacy method; the token is bound to a user account.
 
 Provider configuration options are:
 
-- `token` - (`ESC_TOKEN` via the environment) - *Required* - a refresh token for Kurrent Cloud. This token can be created and displayed with the esc cli tool [esc cli](https://github.com/EventStore/esc), or via the "request refresh token" button on the [Authentification Tokens page](https://console.eventstore.cloud/authentication-tokens) in the console. The token id displayed in the cloud console is not a valid token.
+- `token` - (`ESC_TOKEN` via the environment) - *Required unless Service Account credentials are set* - a refresh token for Kurrent Cloud. This token can be created and displayed with the esc cli tool [esc cli](https://github.com/EventStore/esc), or via the "request refresh token" button on the [Authentification Tokens page](https://console.eventstore.cloud/authentication-tokens) in the console. The token id displayed in the cloud console is not a valid token.
 - `organization_id` - (`ESC_ORG_ID` via the environment) - *Required* - the identifier of the Kurrent Cloud organization into which to provision resources.
 
+- `client_id` - (`ESC_CLIENT_ID` via the environment) - *Optional* - the Service Account client id. Must be set together with `client_secret`.
+- `client_secret` - (`ESC_CLIENT_SECRET` via the environment) - *Optional* - the Service Account client secret. When both `client_id` and `client_secret` are set, Service Account authentication is used and takes priority over `token`. Service Account tokens are held in memory only and are never written to the token store.
 - `url` - (`ESC_URL` via the environment) - *Optional* - the URL of the Kurrent Cloud API. This defaults to the public cloud instance of Kurrent Cloud, but may be overridden to provision resources in another instance.
-- `token_store` - (`ESC_TOKEN_STORE` via the environment) - *Optional* - the location on the local filesystem of the token cache. This is shared with the Kurrent Cloud CLI.
+- `token_store` - (`ESC_TOKEN_STORE` via the environment) - *Optional* - the location on the local filesystem of the token cache. This is shared with the Kurrent Cloud CLI. Only used with refresh token authentication.
+- `identity_kit_url` - (`ESC_IDENTITY_KIT_URL` via the environment) - *Optional* - the base URL of the token endpoint used for Service Account authentication. You would normally not need to set it.
 
 ## Example Usage
 

--- a/templates/index.md.tmpl
+++ b/templates/index.md.tmpl
@@ -18,12 +18,14 @@ Use the navigation to the left to read about the available resources.
 
 The Kurrent Cloud provider supports two authentication methods:
 
-- **Service Account credentials (recommended for automation)** - set `client_id` and `client_secret` to the credentials of a Kurrent Cloud Service Account. The provider then obtains short-lived access tokens via the OAuth2 client-credentials grant, and `token` is not used.
+- **Service Account credentials (recommended)** - set `client_id` and `client_secret` to the credentials of a Kurrent Cloud Service Account. The provider then obtains short-lived access tokens via the OAuth2 client-credentials grant, and `token` is not used.
 - **Refresh token** - set `token` to a personal refresh token. This is the legacy method; the token is bound to a user account.
+
+~> **Deprecation:** Refresh token authentication is a legacy method and will be **decommissioned soon**. Migrate to Service Account credentials (`client_id` / `client_secret`) as described below. Service Accounts are not bound to a user account, hold no token on disk, and are the supported path going forward.
 
 Provider configuration options are:
 
-- `token` - (`ESC_TOKEN` via the environment) - *Required unless Service Account credentials are set* - a refresh token for Kurrent Cloud. This token can be created and displayed with the esc cli tool [esc cli](https://github.com/EventStore/esc), or via the "request refresh token" button on the [Authentification Tokens page](https://console.eventstore.cloud/authentication-tokens) in the console. The token id displayed in the cloud console is not a valid token.
+- `token` - (`ESC_TOKEN` via the environment) - *Required unless Service Account credentials are set* - **(deprecated, see above)** a refresh token for Kurrent Cloud. This token can be created and displayed with the esc cli tool [esc cli](https://github.com/EventStore/esc), or via the "request refresh token" button on the [Authentification Tokens page](https://console.eventstore.cloud/authentication-tokens) in the console. The token id displayed in the cloud console is not a valid token.
 - `organization_id` - (`ESC_ORG_ID` via the environment) - *Required* - the identifier of the Kurrent Cloud organization into which to provision resources.
 
 - `client_id` - (`ESC_CLIENT_ID` via the environment) - *Optional* - the Service Account client id. Must be set together with `client_secret`.

--- a/templates/index.md.tmpl
+++ b/templates/index.md.tmpl
@@ -45,6 +45,8 @@ Provider configuration options are:
 ### Optional
 
 - **client_id** (String)
+- **client_secret** (String, Sensitive)
+- **identity_kit_url** (String)
 - **identity_provider_url** (String)
 - **organization_id** (String)
 - **token** (String, Sensitive)


### PR DESCRIPTION
Add Service Account authentication via the OAuth2 client-credentials grant, mirroring the esc CLI. When client_id and client_secret are both set (ESC_CLIENT_ID / ESC_CLIENT_SECRET), the provider mints short-lived access tokens from the identity kit token endpoint and skips the refresh-token flow. SA tokens are cached in memory only and never written to the on-disk token store.

Also fix closeIgnoreError: it returned a closure that deferred call sites never invoked, so HTTP response bodies were never closed.